### PR TITLE
Add sip009-nft

### DIFF
--- a/clarity/Clarinet.toml
+++ b/clarity/Clarinet.toml
@@ -119,6 +119,11 @@ path = 'contracts/csw-registry.clar'
 clarity_version = 3
 epoch = 3.1
 
+[contracts.sip009-nft]
+path = 'contracts/tests/sip009-nft.clar'
+clarity_version = 3
+epoch = 3.1
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/clarity/README:md
+++ b/clarity/README:md
@@ -1,0 +1,2 @@
+# Clarity Smart Wallets (CSW)
+

--- a/clarity/contracts/tests/sip009-nft.clar
+++ b/clarity/contracts/tests/sip009-nft.clar
@@ -1,0 +1,39 @@
+;; sip009-nft
+;; A SIP009-compliant NFT with a mint function.
+
+(define-constant contract-owner tx-sender)
+
+(define-constant err-owner-only (err u100))
+(define-constant err-token-id-failure (err u101))
+(define-constant err-not-token-owner (err u102))
+
+(define-non-fungible-token stacksies uint)
+(define-data-var token-id-nonce uint u0)
+
+(define-read-only (get-last-token-id)
+	(ok (var-get token-id-nonce))
+)
+
+(define-read-only (get-token-uri (token-id uint))
+	(ok none)
+)
+
+(define-read-only (get-owner (token-id uint))
+	(ok (nft-get-owner? stacksies token-id))
+)
+
+(define-public (transfer (token-id uint) (sender principal) (recipient principal))
+	(begin
+		(asserts! (is-eq tx-sender sender) err-not-token-owner)
+		(nft-transfer? stacksies token-id sender recipient)
+	)
+)
+
+(define-public (mint (recipient principal))
+	(let ((token-id (+ (var-get token-id-nonce) u1)))
+		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
+		(try! (nft-mint? stacksies token-id recipient))
+		(asserts! (var-set token-id-nonce token-id) err-token-id-failure)
+		(ok token-id)
+	)
+)

--- a/clarity/deployments/default.simnet-plan.yaml
+++ b/clarity/deployments/default.simnet-plan.yaml
@@ -177,6 +177,11 @@ plan:
             path: contracts/rule-set-trait.clar
             clarity-version: 3
         - emulated-contract-publish:
+            contract-name: sip009-nft
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/tests/sip009-nft.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: smart-wallet-trait
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/smart-wallet-trait.clar

--- a/clarity/deployments/default.testnet-plan.yaml
+++ b/clarity/deployments/default.testnet-plan.yaml
@@ -10,57 +10,57 @@ plan:
       transactions:
         - requirement-publish:
             contract-id: SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 4680
             path: "./.cache/requirements/SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.clar"
             clarity-version: 1
         - requirement-publish:
             contract-id: SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.commission-trait
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 700
             path: "./.cache/requirements/SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.commission-trait.clar"
             clarity-version: 1
         - requirement-publish:
             contract-id: SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.micro-nthng
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 8860
             path: "./.cache/requirements/SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.micro-nthng.clar"
             clarity-version: 1
         - requirement-publish:
             contract-id: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 8400
             path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
             clarity-version: 1
         - requirement-publish:
             contract-id: SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.ft-trait
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 8350
             path: "./.cache/requirements/SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.ft-trait.clar"
             clarity-version: 1
         - requirement-publish:
             contract-id: SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.restricted-token-trait
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 5480
             path: "./.cache/requirements/SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.restricted-token-trait.clar"
             clarity-version: 1
         - requirement-publish:
             contract-id: SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 104220
             path: "./.cache/requirements/SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin.clar"
             clarity-version: 1
@@ -69,9 +69,9 @@ plan:
       transactions:
         - requirement-publish:
             contract-id: SPDBEG5X8XD50SPM1JJH0E5CTXGDV5NJTKAKKR5V.sip013-semi-fungible-token-trait
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SPDBEG5X8XD50SPM1JJH0E5CTXGDV5NJTKAKKR5V: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SPDBEG5X8XD50SPM1JJH0E5CTXGDV5NJTKAKKR5V: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 9620
             path: "./.cache/requirements/SPDBEG5X8XD50SPM1JJH0E5CTXGDV5NJTKAKKR5V.sip013-semi-fungible-token-trait.clar"
             clarity-version: 1
@@ -80,9 +80,9 @@ plan:
       transactions:
         - requirement-publish:
             contract-id: SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 51810
             path: "./.cache/requirements/SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope.clar"
             clarity-version: 2
@@ -91,9 +91,9 @@ plan:
       transactions:
         - requirement-publish:
             contract-id: SP16GEW6P7GBGZG0PXRXFJEMR3TJHJEY2HJKBP1P5.og-bitcoin-pizza-leather-edition
-            remap-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            remap-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             remap-principals:
-              SP16GEW6P7GBGZG0PXRXFJEMR3TJHJEY2HJKBP1P5: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+              SP16GEW6P7GBGZG0PXRXFJEMR3TJHJEY2HJKBP1P5: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 387280
             path: "./.cache/requirements/SP16GEW6P7GBGZG0PXRXFJEMR3TJHJEY2HJKBP1P5.og-bitcoin-pizza-leather-edition.clar"
             clarity-version: 2
@@ -101,108 +101,122 @@ plan:
     - id: 4
       transactions:
         - contract-publish:
+            contract-name: csw-registry
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 13415
+            path: contracts/csw-registry.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
             contract-name: extension-trait
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 164
             path: contracts/extension-trait.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: emergency-rules
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 371
             path: contracts/rules/emergency-rules.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
-            contract-name: smart-wallet-trait
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
-            cost: 380
-            path: contracts/smart-wallet-trait.clar
-            anchor-block-only: true
-            clarity-version: 3
-        - contract-publish:
             contract-name: ext-delegate-stx-pox-4
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
-            cost: 2159
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 2088
             path: contracts/extensions/ext-delegate-stx-pox-4.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: ext-sponsored-transfer
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 857
             path: contracts/extensions/ext-sponsored-transfer.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: ext-test
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 328
             path: contracts/tests/ext-test.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: ext-unsafe-sip010-transfer
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 936
             path: contracts/extensions/ext-unsafe-sip010-transfer.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
+            contract-name: smart-wallet-with-rules-trait
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 255
+            path: contracts/smart-wallet-with-rules-trait.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
             contract-name: inactive-observer
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
-            cost: 425
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 436
             path: contracts/admin/inactive-observer.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: no-rules
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 355
             path: contracts/rules/no-rules.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: rule-set-trait
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 292
             path: contracts/rule-set-trait.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
+            contract-name: sip009-nft
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 1159
+            path: contracts/tests/sip009-nft.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: smart-wallet-trait
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 289
+            path: contracts/smart-wallet-trait.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: smart-wallet-endpoint
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 1681
+            path: contracts/smart-wallet-endpoint.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
             contract-name: smart-wallet-standard
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
-            cost: 2823
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 2817
             path: contracts/smart-wallet-standard.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
-            contract-name: smart-wallet-standard-endpoint
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
-            cost: 772
-            path: contracts/smart-wallet-standard-endpoint.clar
-            anchor-block-only: true
-            clarity-version: 3
-        - contract-publish:
             contract-name: standard-rules
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 821
             path: contracts/rules/standard-rules.clar
             anchor-block-only: true
             clarity-version: 3
         - contract-publish:
             contract-name: smart-wallet-with-rules
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             cost: 3825
             path: contracts/smart-wallet-with-rules.clar
-            anchor-block-only: true
-            clarity-version: 3
-        - contract-publish:
-            contract-name: smart-wallet-with-rules-endpoint
-            expected-sender: ST3FFRX7C911PZP5RHE148YDVDD9JWVS6FZRA60VS
-            cost: 398
-            path: contracts/smart-wallet-with-rules-endpoint.clar
             anchor-block-only: true
             clarity-version: 3
       epoch: "3.1"

--- a/clarity/deployments/deploy-nft.yaml
+++ b/clarity/deployments/deploy-nft.yaml
@@ -1,0 +1,18 @@
+---
+id: 0
+name: Testnet deployment
+network: testnet
+stacks-node: "https://api.testnet.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-publish:
+            contract-name: sip009-nft
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 1275
+            path: contracts/tests/sip009-nft.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "3.1"

--- a/clarity/deployments/send-nft.yaml
+++ b/clarity/deployments/send-nft.yaml
@@ -1,0 +1,18 @@
+---
+id: 0
+name: Testnet deployment
+network: testnet
+stacks-node: "https://api.testnet.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-call:
+            contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sip009-nft
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            method: mint
+            parameters:
+              - "'ST20AZS8476WEWS0PFW611RF4KTWPWS2NF05NQA8F"
+            cost: 1000
+      epoch: "3.1"


### PR DESCRIPTION
This PR
* adds a SIP 009 nft for testnet
* adds deployment plans to deploy the contract and send the nft.

Deployments on testnet require a file `settings/Testnet.toml`

``` 
[network]
name = "testnet"
[accounts.deployer]
mnemonic = "yourtestnetseedphrase"
``` 